### PR TITLE
Move Startup Logs to the Gulp Task

### DIFF
--- a/main.coffee
+++ b/main.coffee
@@ -22,8 +22,6 @@ module.exports = (opts) ->
         opts.directory = opts.directory or "./bower_components"
 
     dir = opts.directory
-    gutil.log "Bower: Using cwd: ", opts.cwd or process.cwd()
-    gutil.log "Bower: Using bower dir: ", dir
 
     # generate bowerjson automatically
     bowerjson = {
@@ -53,9 +51,10 @@ module.exports = (opts) ->
     testdeps = process_deps(opts.testdeps)
     opts.interactive ?= false
 
-    installtask: (gulp, taskname) ->
-        taskname ?= "bower"
+    installtask: (gulp, taskname = "bower") ->
         gulp.task taskname, [], ->
+            gutil.log "Bower: Using cwd: ", opts.cwd or process.cwd()
+            gutil.log "Bower: Using bower dir: ", dir
             stream = through.obj((file, enc, callback) ->
                 @push file
                 callback()

--- a/main.js
+++ b/main.js
@@ -38,8 +38,6 @@
       opts.directory = opts.directory || "./bower_components";
     }
     dir = opts.directory;
-    gutil.log("Bower: Using cwd: ", opts.cwd || process.cwd());
-    gutil.log("Bower: Using bower dir: ", dir);
     bowerjson = {
       name: 'foo',
       dependencies: {}
@@ -81,6 +79,8 @@
         }
         gulp.task(taskname, [], function() {
           var config, decEndpoints, logger, options, project, stream, tracker;
+          gutil.log("Bower: Using cwd: ", opts.cwd || process.cwd());
+          gutil.log("Bower: Using bower dir: ", dir);
           stream = through.obj(function(file, enc, callback) {
             this.push(file);
             callback();


### PR DESCRIPTION
This way we don't get Bower logs when calling tasks that don't depend on it.
