### PR TITLE
Fixes support when run in strict mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ https://github.com/zont/gulp-bower
 
 ### Changelog
 
+#### 0.3.2
+* Fix support for strict mode.
+
+#### 0.3.1
+* Fix an issue where bowerdeps only works on a second run.
+
 #### 0.3.0
 * Generate a bowerdeps.js, which contain the metadata for the dependencies embedded in the deps source files
 

--- a/main.coffee
+++ b/main.coffee
@@ -83,7 +83,8 @@ module.exports = (opts) ->
             decEndpoints = []
             tracker.trackDecomposedEndpoints('install', decEndpoints)
             project.install(decEndpoints, options, config).then (installed) ->
-                summary = "BOWERDEPS = (typeof BOWERDEPS === 'undefined') ? {}: BOWERDEPS;"
+                summary = "(function(){ var _global = (0, eval)('this');\n"
+                summary += "if (typeof _global.BOWERDEPS === 'undefined') { _global.BOWERDEPS = {}; }\n"
                 for k, v of project._manager._installed
                     if v?
                         installed[k] = {pkgMeta: v}
@@ -96,8 +97,9 @@ module.exports = (opts) ->
                     return JSON.stringify(r)
                 for k, v of opts.deps
                     if installed.hasOwnProperty(k)
-                        summary += "\nBOWERDEPS['#{k}'] = "
+                        summary += "\n_global.BOWERDEPS['#{k}'] = "
                         summary += "#{stripPrivate(installed[k].pkgMeta)};"
+                summary += "})();"
                 fs.writeFileSync(summaryfile, summary)
                 stream.end()
                 stream.emit "end"

--- a/main.js
+++ b/main.js
@@ -112,7 +112,8 @@
           tracker.trackDecomposedEndpoints('install', decEndpoints);
           project.install(decEndpoints, options, config).then(function(installed) {
             var k, stripPrivate, summary, v, _ref, _ref1;
-            summary = "BOWERDEPS = (typeof BOWERDEPS === 'undefined') ? {}: BOWERDEPS;";
+            summary = "(function(){ var _global = (0, eval)('this');\n";
+            summary += "if (typeof _global.BOWERDEPS === 'undefined') { _global.BOWERDEPS = {}; }\n";
             _ref = project._manager._installed;
             for (k in _ref) {
               v = _ref[k];
@@ -138,10 +139,11 @@
             for (k in _ref1) {
               v = _ref1[k];
               if (installed.hasOwnProperty(k)) {
-                summary += "\nBOWERDEPS['" + k + "'] = ";
+                summary += "\n_global.BOWERDEPS['" + k + "'] = ";
                 summary += "" + (stripPrivate(installed[k].pkgMeta)) + ";";
               }
             }
+            summary += "})();";
             fs.writeFileSync(summaryfile, summary);
             stream.end();
             return stream.emit("end");

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "engines": {
     "node": "~0.10"
   },
-  "version": "0.3.1",
+  "version": "0.3.2",
   "license": "MIT",
   "readmeFilename": "README.md",
   "scripts": {}


### PR DESCRIPTION
Currently the code may fail with `ReferenceError` if the generated bowerdeps.js is not run in global scope and is run in strict mode, both of which depend on the package manager in use. This PR fixes this.